### PR TITLE
fixes #94 : Settings: add option to disable file download by token

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
 	"title": "YouTransfer",
 	"subtitle": "The self-hosted file sharing solution",
 	"baseUrl": "http://localhost:5000",
+	"enableDownload": true,
 
 	"dropzone": {
 		"maxFilesize": "2000",

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -96,7 +96,6 @@ Router.prototype.send = function() {
 };
 
 Router.prototype.download = function() {
-	var self = this;
 	return function(req, res, next) {
 
 		req.errors.register([

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -96,6 +96,7 @@ Router.prototype.send = function() {
 };
 
 Router.prototype.download = function() {
+	var self = this;
 	return function(req, res, next) {
 
 		req.errors.register([
@@ -120,6 +121,7 @@ Router.prototype.download = function() {
 		} else {
 			youtransfer.download(token, res, callback);
 		}
+
 	};
 };
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -56,10 +56,21 @@ Settings.prototype.push = function(settings, next) {
 
 	fs.readFile(self.options.path, self.options.encoding, function(err, content) {
 		try {
+
+			var config = require('../config.json');
 			var current = content ? JSON.parse(content) : {};
-			var output = _.assign(current, settings);
-			output = _.pick(output, _.identity);
-			
+			current = _.assign({}, config, current);
+
+			// Fixing the problem with missing boolean values (checkboxes)
+			_.forOwn(current, function(value, key) {
+				if(_.isBoolean(value) || value === 'true') {
+					if(_.isUndefined(settings[key])) {
+						settings[key] = false;
+					}
+				}
+			});
+
+			var output = _.assign({}, current, settings);
 			fs.writeFile(self.options.path, JSON.stringify(output), self.options.encoding, function(err) {
 				self.emit('settings.push', err, output);
 				next(err);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "aws-sdk": "^2.1.45",
     "commander": "^2.8.1",
     "compression": "^1.5.2",
-    "crypto-js": "^3.1.5",
     "date-utils": "^1.2.17",
     "filesize": "^3.1.3",
     "fs-extra": "^0.23.1",

--- a/src/views/pages/download.html
+++ b/src/views/pages/download.html
@@ -6,7 +6,34 @@
 		<h1>{{ title | safe }}</h1>
 		<h2>{{ subtitle | safe }}</h2>
 	</header>
+
+	{% if enableDownload %}
+
 	{% include "gettoken.html" %}
+
+	{% elif errors.length > 0 %}
+
+		<div class="download text-center">
+			{% import "errors.html" as err %}
+			{{ err.show(errors) }}
+		</div>
+
+	{% else %}
+
+		<div class="download text-center">
+			<div class="help-block">
+				<div class="text-danger">
+					<p>
+						Err... this is awkward...<br />
+						File download by token has been disabled.<br />
+						Didn't you get the memo?
+					</p>
+				</div>
+			</div>
+		</div>
+
+	{% endif %}
+
 	<div class="text-center">
 		<a href="/" data-async data-target="dl">or return to homepage</a>
 	</div>

--- a/src/views/pages/index.html
+++ b/src/views/pages/index.html
@@ -1,13 +1,13 @@
 {% extends "layout.html" %}
 
 {% block content %}
-<div class="hp jumbotron" id="hp">
+<div class="hp jumbotron {{"col-md-6" if not enableDownload }}" id="hp">
 	<header class="col-md-12">
 		<h1>{{ title | safe }}</h1>
 		<h2>{{ subtitle | safe }}</h2>
 	</header>
 
-	<div class="{{ "col-md-6" if success else "col-md-12" }}">
+	<div class="{{ "col-md-6" if success and enableDownload else "col-md-12" }}">
 		{%if isPostback %}
 
 			{% if success %}
@@ -31,13 +31,13 @@
 	</div>
 
 	{% if success %}
-	<div class="col-md-6 dz-completed-container">
+	<div class="{{"col-md-6" if enableDownload else "col-md-12" }} dz-completed-container">
 
 		{%if isPostback %}
 
 			{% include "sendmail.html" %}
 
-		{% else %}
+		{% elif enableDownload %}
 
 		<div class="separator text-center">
 			<h6 class="separator-text"><em>or</em></h6>

--- a/src/views/pages/settings.general.html
+++ b/src/views/pages/settings.general.html
@@ -51,6 +51,17 @@
 		</div>
 
 		<div class="form-group">
+			<div class="col-sm-offset-3 col-sm-9">
+				<div class="checkbox">
+					<label for="enableDownload">
+						<input type="checkbox" name="settings[enableDownload]" id="enableDownload" {{ "checked" if enableDownload }} value="true">
+						Enable file download feature
+					</label>
+				</div>
+			</div>
+		</div>
+
+		<div class="form-group">
 			<div class="col-sm-offset-3 col-sm-6 text-right">
 				<button type="submit" class="btn btn-primary">Save</button>
 			</div>

--- a/test/modules/settings.test.js
+++ b/test/modules/settings.test.js
@@ -87,6 +87,70 @@ describe('YouTransfer Settings module', function() {
 
 	});
 
+	it('should be possible to set boolean value to true explicitely', function(done) {
+
+		sandbox.stub(fs, 'readFile', function (file, encoding, callback) {
+			callback(null, JSON.stringify({
+				booleanValue: true
+			}));
+		});
+
+		sandbox.stub(fs, 'writeFile', function (file, data, encoding, callback) {
+			var settings = JSON.parse(data);
+			settings.booleanValue.should.equals(true);
+			callback(null);
+		});
+
+		settings.push({ booleanValue: true }, function(err) {
+			should.not.exist(err);
+			done();
+		});
+
+	});
+
+	it('should be possible to set boolean value to false explicitely', function(done) {
+
+		sandbox.stub(fs, 'readFile', function (file, encoding, callback) {
+			callback(null, JSON.stringify({
+				booleanValue: true
+			}));
+		});
+
+		sandbox.stub(fs, 'writeFile', function (file, data, encoding, callback) {
+			var settings = JSON.parse(data);
+			settings.booleanValue.should.equals(false);
+			callback(null);
+		});
+
+		settings.push({ booleanValue: false }, function(err) {
+			should.not.exist(err);
+			done();
+		});
+
+	});
+
+	it('should be possible to set boolean value to false by omission', function(done) {
+
+		sandbox.stub(fs, 'readFile', function (file, encoding, callback) {
+			callback(null, JSON.stringify({
+				booleanValue: true
+			}));
+		});
+
+		sandbox.stub(fs, 'writeFile', function (file, data, encoding, callback) {
+			var settings = JSON.parse(data);
+			settings.booleanValue.should.equals(false);
+			callback(null);
+		});
+
+		settings.push({}, function(err) {
+			should.not.exist(err);
+			done();
+		});
+
+	});
+
+
 	it('should throw an error if it is not possible to write settings file', function(done) {
 		sandbox.stub(fs, 'readFile', function (file, encoding, callback) {
 			callback(null, 'this is not json and should produce an error');

--- a/test/views/download/download.test.js
+++ b/test/views/download/download.test.js
@@ -73,4 +73,39 @@ describe('Download View', function() {
 
 	});
 
+	it('should not have a form to enable downloading a file if this feature is disabled', function *() {
+
+		var currentValue = sandbox.enableDownload;
+		if(currentValue) {
+			var enableDownload = yield browser.click('ul.nav > li > a')
+											  .click('input#enableDownload')
+											  .submitForm('.tab-pane.active form')
+											  .waitForExist('.tab-pane.active .alert strong', 5000)
+											  .isExisting('input#enableDownload:checked');
+			enableDownload.should.be.equal(false);
+		}
+
+		var form = yield browser.url(sandbox.baseUrl + '/download')
+								.isExisting('.download form');
+		form.should.be.equal(false);
+
+		var submit = yield browser.url(sandbox.baseUrl + '/download')
+								  .isExisting('.download form button[type=submit]');
+		submit.should.be.equal(false);
+
+		var error = yield browser.url(sandbox.baseUrl + '/download')
+								 .getText('.text-danger');
+		error.should.equals("Err... this is awkward...\nFile download by token has been disabled.\nDidn\'t you get the memo?");
+
+		var currentValue = sandbox.enableDownload;
+		if(currentValue) {
+			var enableDownload = yield browser.click('ul.nav > li > a')
+											  .click('input#enableDownload')
+											  .submitForm('.tab-pane.active form')
+											  .waitForExist('.tab-pane.active .alert strong', 5000)
+											  .isExisting('input#enableDownload:checked');
+			enableDownload.should.be.equal(true);
+		}
+
+	});
 });

--- a/test/views/index/index.test.js
+++ b/test/views/index/index.test.js
@@ -74,6 +74,42 @@ describe('Index View', function() {
 
 	});
 
+	it('should not have a form to enable downloading a file if this feature is disabled', function *() {
+
+		var currentValue = sandbox.enableDownload;
+		if(currentValue) {
+			var enableDownload = yield browser.click('ul.nav > li > a')
+											  .click('input#enableDownload')
+											  .submitForm('.tab-pane.active form')
+											  .waitForExist('.tab-pane.active .alert strong', 5000)
+											  .isExisting('input#enableDownload:checked');
+			enableDownload.should.be.equal(false);
+		}
+
+		var download = yield browser.url('/')
+									.isExisting('.download');
+		download.should.be.equal(false);
+
+		var form = yield browser.url('/')
+								.isExisting('.download form');
+		form.should.be.equal(false);
+
+		var submit = yield browser.url('/')
+								  .isExisting('.download form button[type=submit]');
+		submit.should.be.equal(false);
+
+		var currentValue = sandbox.enableDownload;
+		if(currentValue) {
+			var enableDownload = yield browser.click('ul.nav > li > a')
+											  .click('input#enableDownload')
+											  .submitForm('.tab-pane.active form')
+											  .waitForExist('.tab-pane.active .alert strong', 5000)
+											  .isExisting('input#enableDownload:checked');
+			enableDownload.should.be.equal(true);
+		}
+
+	});
+
 	it('should have a form to enable downloading a file which throws an error when trying to exploit path traversal', function *() {
 
 		var form = yield browser.isExisting('.download form');

--- a/test/views/settings/settings.general.test.js
+++ b/test/views/settings/settings.general.test.js
@@ -70,6 +70,18 @@ describe('General Settings View', function() {
 
 	});
 
+	it('should have a "Enable file download feature" field with the current value based on user settings', function *() {
+
+		var value = yield browser.getAttribute('input#enableDownload', 'checked')
+		if(sandbox.enableDownload) {
+			should.exist(value);
+		} else {
+			should.not.exist(value);
+		}
+
+	});
+
+
 	it('should be able to save the settings', function *() {
 
 		var alert = yield browser.isExisting('.tab-pane.active .alert strong');


### PR DESCRIPTION
fixes #94 : Settings: add option to disable file download by token
- Introduced feature checkbox on general settings page
- Set default value to 'true' in the config.son
- Removed download form from hp as well as download page when disabled
- Changed UI to facilitate the option
- Fixed an issue with saving user settings and checkboxes (long story)
- Created UI and unit tests accordingly