### PR TITLE
fs.readFile & fs.writeFile encoding 'utf-8' should be replaced by 'utf8'

### DIFF
--- a/lib/localstorage.js
+++ b/lib/localstorage.js
@@ -66,7 +66,7 @@ LocalFileStorage.prototype.upload = function(file, context, next) {
 					if(err) {
 						next(err, context);
 					} else {
-						fs.writeFile(context.jsonPath, JSON.stringify(context), 'utf-8', function(err) {
+						fs.writeFile(context.jsonPath, JSON.stringify(context), 'utf8', function(err) {
 							next(err, context);
 						});
 					}
@@ -80,7 +80,7 @@ LocalFileStorage.prototype.upload = function(file, context, next) {
 LocalFileStorage.prototype.bundle = function(bundle, next) {
 	var basedir = path.dirname(bundle.path);
 	fs.mkdir(basedir, function() {
-		fs.writeFile(bundle.path, JSON.stringify(bundle), 'utf-8', function(err) {
+		fs.writeFile(bundle.path, JSON.stringify(bundle), 'utf8', function(err) {
 			next(err);
 		});
 	});
@@ -97,7 +97,7 @@ LocalFileStorage.prototype.archive = function(token, res, next) {
 				throw new Error('Invalid token provided');
 			}
 
-			fs.readFile(bundlePath, 'utf-8', function(err, data) {
+			fs.readFile(bundlePath, 'utf8', function(err, data) {
 				try {
 					if(err) {
 						throw err;
@@ -171,7 +171,7 @@ LocalFileStorage.prototype.download = function(token, res, next) {
 				throw new Error('Invalid token provided');
 			}
 
-			fs.readFile(tokenPath, 'utf-8', function(err, data) {
+			fs.readFile(tokenPath, 'utf8', function(err, data) {
 				try {
 					if(err) {
 						throw err;
@@ -220,7 +220,7 @@ LocalFileStorage.prototype.purge = function(next) {
 		var filesToDelete = [];
 		_.each(files, function(file) {
 			if(file.match(/.json$/)) {
-				fs.readFile(path.join(basedir, file), 'utf-8', function(err, data) {
+				fs.readFile(path.join(basedir, file), 'utf8', function(err, data) {
 					var context = JSON.parse(data);
 					if(context.expires) {
 						var expires = new Date(context.expires);

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -207,7 +207,7 @@ Router.prototype.settingsGetTemplateByName = function() {
 				} else if(!template) {
 					throw req.errors.custom('ENOENT');
 				} else {
-					fs.readFile('./src/templates/' + template, 'utf-8', function(err, data) {
+					fs.readFile('./src/templates/' + template, 'utf8', function(err, data) {
 						if(err) {
 							req.errors.parse(err);
 							res.process('settings.template.html', null, next);
@@ -254,7 +254,7 @@ Router.prototype.settingsSaveTemplate = function() {
 				} else if(!template) {
 					throw req.errors.custom('ENOENT');
 				} else {
-					fs.writeFile('./src/templates/' + template, req.params.body, 'utf-8', function(err) {
+					fs.writeFile('./src/templates/' + template, req.params.body, 'utf8', function(err) {
 						req.errors.parse(err);
 						self.settingsGetByName()(req, res, next);
 					});

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -22,7 +22,7 @@ function Settings(opt) {
 	} else if(_.isObject(this.options)) {
 		this.options = _.assign({
 			path: './settings.json',
-			encoding: 'utf-8'
+			encoding: 'utf8'
 		}, opt);
 	} else {
 		throw 'Invalid options provided';


### PR DESCRIPTION
As per Node.js documentation, the encoding value that you pass to functions fs.readFile() & fs.writeFile() should be "utf8" instead of "utf-8". You can check the documentation here:

https://nodejs.org/api/fs.html#fs_fs_writefile_filename_data_options_callback
https://nodejs.org/api/fs.html#fs_fs_readfile_filename_options_callback