### PR TITLE
Exposed port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,6 @@ RUN npm install youtransfer -g
 RUN youtransfer init
 RUN npm install
 
+EXPOSE 5000
+
 CMD npm run dockerized


### PR DESCRIPTION
Exposing port 5000 for use with docker proxy services. Without exposing a port they won't work out of the box without explicitly binding a port with -P or -p

This allows us to do something like this and traffic to be routed properly: 
```bash
docker run -d -e VIRTUAL_HOST=blah.example.com remie/youtransfer:stable
```
